### PR TITLE
New event: Entity (ENTITY=zombie)

### DIFF
--- a/src/main/java/circuitlord/reactivemusic/SongLoader.java
+++ b/src/main/java/circuitlord/reactivemusic/SongLoader.java
@@ -1,6 +1,7 @@
 	package circuitlord.reactivemusic;
 
     import net.fabricmc.loader.api.FabricLoader;
+    import net.minecraft.entity.EntityType;
     import net.minecraft.world.biome.Biome;
     import org.yaml.snakeyaml.Yaml;
 
@@ -240,6 +241,22 @@
 
                             // go to next event
                             if (foundTag) continue;
+                        }
+			
+			// try to figure out if it's an entity=
+                        if (val.startsWith("entity=")) {
+                            String entityName = val.substring(7);
+
+                            boolean foundEntityType = false;
+                            var entityType = EntityType.get(entityName);
+                            // Check if an EntityType of entityName exists
+                            if (EntityType.get(entityName).isPresent()) {
+                                songpack.entries[i].entityEvents.add(entityType.get());
+                                foundEntityType = true;
+                            }
+
+                            // go to next event
+                            if (foundEntityType) continue;
                         }
 
                         // last case -- try casting to songpack event enum

--- a/src/main/java/circuitlord/reactivemusic/SongPicker.java
+++ b/src/main/java/circuitlord/reactivemusic/SongPicker.java
@@ -10,8 +10,10 @@ import net.minecraft.client.gui.screen.CreditsScreen;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
 
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.HostileEntity;
-import net.minecraft.entity.mob.Monster;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.Monster; // note: unused atm
 import net.minecraft.entity.passive.HorseEntity;
 import net.minecraft.entity.passive.PigEntity;
 import net.minecraft.entity.passive.VillagerEntity;
@@ -37,6 +39,9 @@ public final class SongPicker {
 
     public static Map<TagKey<Biome>, Boolean> biomeTagEventMap = new HashMap<>();
 
+    // This can probably be done differently (I'm tired, boss...)
+    public static Map<EntityType<?>, Boolean> entityEventMap = new HashMap<>();
+    
     public static Map<Entity, Long> recentEntityDamageSources = new HashMap<>();
 
 
@@ -136,7 +141,7 @@ public final class SongPicker {
 
         // Weather
         songpackEventMap.put(SongpackEventType.RAIN, world.isRaining());
-
+        // TODO: implement SNOW
 
         // TODO: WILL BE REMOVED, use biomeTagEventMap
         songpackEventMap.put(SongpackEventType.MOUNTAIN, biome.isIn(BiomeTags.IS_MOUNTAIN));
@@ -148,7 +153,7 @@ public final class SongPicker {
             biomeTagEventMap.put(tag, biome.isIn(tag));
         }
 
-/*        var biomeTagsList = biome.streamTags().toList();
+        /* var biomeTagsList = biome.streamTags().toList();
 
         for (var tag : biomeTagsList) {
             System.out.println(tag.id().toString());
@@ -191,6 +196,26 @@ public final class SongPicker {
 
         }
 
+        // TODO: change entityEventMap to Map of <entityTypes, numberOfEntities> for threshold requirements
+        // TODO: this would probably also work for checking hostile mobs & villagers from the same map
+        {
+            entityEventMap.clear();
+            //int entityCount = 0;
+
+            double radiusXZ = 30.0;
+            double radiusY = 15.0;
+            // This might as well be GetBoxAroundPlayer
+            Box box = new Box(player.getX() - radiusXZ, player.getY() - radiusY, player.getZ() - radiusXZ,
+                    player.getX() + radiusXZ, player.getY() + radiusY, player.getZ() + radiusXZ);
+
+            List<MobEntity> nearbyEntityCheck = mc.world.getEntitiesByClass(MobEntity.class, box, entity -> entity != null);
+
+            for (MobEntity entity : nearbyEntityCheck) {
+                entityEventMap.put(entity.getType(), nearbyEntityCheck.size() >= 1);
+                ReactiveMusic.LOGGER.info("Entity type: " + String.valueOf(entity.getType()));
+            }
+        }
+        
         {
             List<HostileEntity> nearbyHostile = world.getEntitiesByClass(HostileEntity.class,
                     GetBoxAroundPlayer(player, 12.f, 6.f),
@@ -239,6 +264,7 @@ public final class SongPicker {
     public static void initialize() {
 
         songpackEventMap.clear();
+        entityEventMap.clear(); // I think this is superfluous
 
         for (SongpackEventType eventType : SongpackEventType.values()) {
             songpackEventMap.put(eventType, false);
@@ -313,6 +339,16 @@ public final class SongPicker {
                 }
             }
 
+            for (EntityType<?> entityEvent : entry.entityEvents) {
+                if (!entityEventMap.containsKey(entityEvent))
+                {
+                    //continue;
+                //if (!entityEventMap.get(entityEvent)) {
+                    eventsMet = false;
+                    break;
+                }
+            }
+            
             for (TagKey<Biome> biomeTagEvent : entry.biomeTagEvents) {
 
                 if (!biomeTagEventMap.containsKey(biomeTagEvent))

--- a/src/main/java/circuitlord/reactivemusic/SongPicker.java
+++ b/src/main/java/circuitlord/reactivemusic/SongPicker.java
@@ -212,7 +212,7 @@ public final class SongPicker {
 
             for (MobEntity entity : nearbyEntityCheck) {
                 entityEventMap.put(entity.getType(), nearbyEntityCheck.size() >= 1);
-                ReactiveMusic.LOGGER.info("Entity type: " + String.valueOf(entity.getType()));
+                // ReactiveMusic.LOGGER.info("Entity type: " + String.valueOf(entity.getType()));
             }
         }
         

--- a/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
@@ -3,6 +3,7 @@ package circuitlord.reactivemusic;
 import net.minecraft.loot.entry.TagEntry;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.entity.EntityType;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
@@ -25,4 +25,5 @@ public class SongpackEntry {
     public int id = -1;
     public List<SongpackEventType> songpackEvents = new ArrayList<>();
     public List<TagKey<Biome>> biomeTagEvents = new ArrayList<>();
+    public List<EntityType<?>> entityEvents = new ArrayList<>();
 }

--- a/src/main/resources/musicpack/ReactiveMusic.yaml
+++ b/src/main/resources/musicpack/ReactiveMusic.yaml
@@ -22,6 +22,13 @@ entries:
 #      - "CastleInTheSky"
 #      - "CircleOfLife"
 
+#   TODO: check if this works with modded mobs as well (with modname:mobname)
+  - events: ["ENTITY=zombie"]
+    alwaysPlay: true
+    alwaysStop: true
+    songs:
+      - "LastStand"
+      - "Ruthless"
 
 
   - events: [ "UNDERWATER" ]


### PR DESCRIPTION
Hello! This adds a tag to the config similar to `"BIOME=xxxx"`, specified as `"ENTITY=xxxx"`. This was inspired by #26 . This allows custom music events for different mob entities. Implementation may need to be tweaked, as some mobs such as Ender Dragon you'd want to detect from much further away. In the future, could maybe be made configurable like `"ENTITY=zombie, 100"` to look for the mob in a different radius, or maybe for the number of mobs of a certain kind (like Villager).

Please try out and let me know what you think!