### PR TITLE
add "stackable" property

### DIFF
--- a/src/main/java/circuitlord/reactivemusic/ReactiveMusic.java
+++ b/src/main/java/circuitlord/reactivemusic/ReactiveMusic.java
@@ -206,7 +206,7 @@ public class ReactiveMusic implements ModInitializer {
 			for (var entry : validEntries) {
 				// if this entry can stack on entries below it, keep it in a separate list to add to the song picker pool
 				// only consider when the size of valid entries is more than 1
-				if (entry.stackOnFallback && validEntries.size() > 1) {
+				if (entry.stackable && validEntries.size() > 1) {
 					selectedSongs = ArrayUtils.addAll(selectedSongs, entry.songs);
 					continue;
 				}
@@ -230,7 +230,7 @@ public class ReactiveMusic implements ModInitializer {
 				for (var i = 0; i < validEntries.size(); i++) {
 					newEntry = validEntries.get(i);
 					// choose an entry that is not stackable unless it's the only entry in the list
-					if (!newEntry.stackOnFallback || validEntries.size() == 1)
+					if (!newEntry.stackable || validEntries.size() == 1)
 						break;
 				}
 			}

--- a/src/main/java/circuitlord/reactivemusic/ReactiveMusic.java
+++ b/src/main/java/circuitlord/reactivemusic/ReactiveMusic.java
@@ -8,6 +8,7 @@ import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallba
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ public class ReactiveMusic implements ModInitializer {
 
 	static String currentSong = null;
 	static SongpackEntry currentEntry = null;
+	static List<SongpackEntry> currentGenericEntries = new ArrayList<>();
 	
 	//static String nextSong;
 	static int waitForSwitchTicks = 0;
@@ -195,11 +197,19 @@ public class ReactiveMusic implements ModInitializer {
 		validEntries = SongPicker.getAllValidEntries();
 
 		SongpackEntry newEntry = null;
+		String[] selectedSongs = {};
 
 		if (!currentDimBlacklisted) {
+			currentGenericEntries.clear();
 
 			// Try to find the highest entry with a song we haven't played recently
 			for (var entry : validEntries) {
+				// if this entry can stack on entries below it, keep it in a separate list to add to the song picker pool
+				// only consider when the size of valid entries is more than 1
+				if (entry.stackOnFallback && validEntries.size() > 1) {
+					selectedSongs = ArrayUtils.addAll(selectedSongs, entry.songs);
+					continue;
+				}
 
 				// if this is the same entry and we're still playing the song we picked, keep it
 				if (currentEntry == entry && thread.isPlaying()) {
@@ -217,9 +227,17 @@ public class ReactiveMusic implements ModInitializer {
 
 			// if we didn't find any entries, just use the highest priority one
 			if (newEntry == null && !validEntries.isEmpty()) {
-				newEntry = validEntries.get(0);
+				for (var i = 0; i < validEntries.size(); i++) {
+					newEntry = validEntries.get(i);
+					// choose an entry that is not stackable unless it's the only entry in the list
+					if (!newEntry.stackOnFallback || validEntries.size() == 1)
+						break;
+				}
 			}
 
+			if (newEntry != null) {
+				selectedSongs = ArrayUtils.addAll(selectedSongs, newEntry.songs);
+			}
 		}
 
 
@@ -229,7 +247,7 @@ public class ReactiveMusic implements ModInitializer {
 		// --- main loop, check new entry and see if we should play it ---
 
 		// If a new valid entry exists, check it
-		if (newEntry != null && newEntry.songs.length > 0) {
+		if (newEntry != null && selectedSongs.length > 0) {
 
 
 			if (currentEntry == null || newEntry.id != currentEntry.id) waitForSwitchTicks++;
@@ -280,14 +298,14 @@ public class ReactiveMusic implements ModInitializer {
 					&& (currentEntry.alwaysStop || newEntry.alwaysPlay || config.debugModeEnabled)
 
 					// make sure the new entry doesn't have the song we're playing already -- because then we wouldn't want to switch
-					&& !Arrays.asList(newEntry.songs).contains(currentSong)
+					&& !Arrays.asList(selectedSongs).contains(currentSong)
 			) {
 
 				tickFadeOut();
 			}
 
 			if (playNewSong) {
-				String picked = SongPicker.pickRandomSong(newEntry.songs);
+				String picked = SongPicker.pickRandomSong(selectedSongs);
 				changeCurrentSong(picked, newEntry);
 
 				int minTickSilence = 0;

--- a/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
@@ -19,7 +19,7 @@ public class SongpackEntry {
 
     public boolean allowFallback = true;
 
-    public boolean stackOnFallback = false;
+    public boolean stackable = false;
 
     public String[] songs;
 

--- a/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
+++ b/src/main/java/circuitlord/reactivemusic/SongpackEntry.java
@@ -19,6 +19,8 @@ public class SongpackEntry {
 
     public boolean allowFallback = true;
 
+    public boolean stackOnFallback = false;
+
     public String[] songs;
 
     // Not part of user-facing config, loaded in SongLoader


### PR DESCRIPTION
hi,

this is a PR that adds the ability to stack songs in the queue depending on the events, which can be enabled by using `stackable` property (default to `false`). this has minor changes on how song entries are picked, which is expected to not make any prolonging issues... I hope.

this is good for use cases where the songpack:

- wants to support overlapping events, but also need those events to be separate entries
- wants some variety to the music selection pool depending on the events.

there are workaround methods, but it can get tedious when making larger packs.

*(if set, this property bypasses `allowFallback: false`, since if it's stackable it means it would always fallback)*